### PR TITLE
Add a note regarding lockfile differences from patch-package

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This tool does what [patch-package](https://www.npmjs.com/package/patch-package)
 - it never chokes on its own patches
 - it does not break if you try to apply a patch more than once (but shows a warning)
 - it does not require/depend on GIT
+- it does not require a package-lock.json or yarn.lock present when creating patches
  
 When you have made a bugfix for one of your dependencies but the author/maintainers refuse to accept your PR - you do not need to fork the package.
 Create a patch and seamlessly apply it locally for all your builds.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This tool does what [patch-package](https://www.npmjs.com/package/patch-package)
 - it never chokes on its own patches
 - it does not break if you try to apply a patch more than once (but shows a warning)
 - it does not require/depend on GIT
-- it does not require a package-lock.json or yarn.lock present when creating patches
+- it does not require a lockfile present when creating patches
  
 When you have made a bugfix for one of your dependencies but the author/maintainers refuse to accept your PR - you do not need to fork the package.
 Create a patch and seamlessly apply it locally for all your builds.


### PR DESCRIPTION
An arbitrary requirement of patch-package is that a lockfile is required to generate patches, but not apply them. It's nice to see that isn't the case here.